### PR TITLE
修正 cp 在 Mac 上可能會無法正確 copy 的問題

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@
 case `uname -s` in
   "Darwin" )
     PLATFORM="mac"
-    RIME_HOME="~/Library/Rime"
+    RIME_HOME="$HOME/Library/Rime"
     ;;
   "Linux" )
     PLATFORM="linux"


### PR DESCRIPTION
- ~ 這個雖然意指使用者的 home 可能會出錯，使用 $HOME 確保這個路徑可以正確被解譯
